### PR TITLE
Update denied-peer-ip

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,14 @@ coturn_denied_peer_ips:
   - 198.51.100.0-198.51.100.255
   - 203.0.113.0-203.0.113.255
   - 240.0.0.0-255.255.255.255
+  - ::1
+  - 64:ff9b::-64:ff9b::ffff:ffff
+  - ::ffff:0.0.0.0-::ffff:255.255.255.255
+  - 100::-100::ffff:ffff:ffff:ffff
+  - 2001::-2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff
+  - 2002::-2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+  - fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+  - fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 
 # 1 for verbose, 2 for Verbose (very verbose)
 coturn_verbosity: 0


### PR DESCRIPTION
New defaults from: https://www.rtcsec.com/post/2021/01/details-about-cve-2020-26262-bypass-of-coturns-default-access-control-protection/