### PR TITLE
Add configuration options for allocation and bandwidth limits

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,28 @@ coturn_denied_peer_ips:
 
 # 1 for verbose, 2 for Verbose (very verbose)
 coturn_verbosity: 0
+
+# Total allocation quota.
+# default value is 0 (no quota).
+#
+# Number of allowed simultaneous connections to the TURN server. Along with
+# max-bps and bps-capacity it can be used to limit the effects of a DoS attack
+# against the TURN server. The value of 0 means unlimited; if a connection
+# limit is desired it should be adjusted depending on your specific setup.
+#
+# see: https://tools.ietf.org/html/rfc8656#section-21.3.1
+coturn_total_quota: 0
+
+# Per-user allocation quota
+# default value is 0 (no quota, unlimited number of sessions per user).
+coturn_user_quota: 0
+
+# Max bytes-per-second bandwidth a TURN session is allowed to handle (input and
+# output network streams are treated separately). Anything above that limit
+# will be dropped or temporary suppressed (within the available buffer limits).
+coturn_max_bps: 0
+
+# Maximum server capacity. Total bytes-per-second bandwidth the TURN server is
+# allowed to allocate for the sessions, combined (input and output network
+# streams are treated separately).
+coturn_bps_capacity: 0

--- a/templates/turnserver.conf.j2
+++ b/templates/turnserver.conf.j2
@@ -360,13 +360,13 @@ realm={{ coturn_realm }}
 # default value is 0 (no quota, unlimited number of sessions per user).
 # This option can also be set through the database, for a particular realm.
 #
-#user-quota=0
+user-quota={{ coturn_user_quota }}
 
 # Total allocation quota.
 # default value is 0 (no quota).
 # This option can also be set through the database, for a particular realm.
 #
-total-quota=100
+total-quota={{ coturn_total_quota }}
 
 # Max bytes-per-second bandwidth a TURN session is allowed to handle
 # (input and output network streams are treated separately). Anything above
@@ -374,14 +374,14 @@ total-quota=100
 # the available buffer limits).
 # This option can also be set through the database, for a particular realm.
 #
-#max-bps=0
+max-bps={{ coturn_max_bps }}
 
 #
 # Maximum server capacity.
 # Total bytes-per-second bandwidth the TURN server is allowed to allocate
 # for the sessions, combined (input and output network streams are treated separately).
 #
-bps-capacity=0
+bps-capacity={{ coturn_bps_capacity }}
 
 # Uncomment if no UDP client listener is desired.
 # By default UDP client listener is always started.


### PR DESCRIPTION
Note that the current hard coded value for `total-quota` is almost certainly too low for most deployments. I recommend to set it to unlimited by default.