### PR TITLE
Support running coturn on privileged port (e.g., 443)

### DIFF
--- a/files/systemd-cap-net-bind-override.conf
+++ b/files/systemd-cap-net-bind-override.conf
@@ -1,0 +1,3 @@
+[Service]
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,10 @@
 ---
 
+
+- name: reload systemd
+  systemd:
+    daemon_reload: true
+
 - name: restart coturn
   service:
     name: coturn

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,9 @@
     mode: 0644
   notify: restart coturn
 
+- when: ansible_service_mgr == "systemd"
+  import_tasks: systemd.yml
+
 - name: start coturn
   service:
     name: coturn

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,9 @@
 - when: ansible_service_mgr == "systemd"
   import_tasks: systemd.yml
 
+- name: reload systemd and restart coturn if necessary
+  meta: flush_handlers
+
 - name: start coturn
   service:
     name: coturn

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -11,8 +11,8 @@
         mode: 0755
 
     - name: Listening on privileged port granted
-      register: coturn_cap_net_bind_result
       notify:
+        - reload systemd
         - restart coturn
       copy:
         src: systemd-cap-net-bind-override.conf
@@ -21,22 +21,12 @@
         group: root
         mode: 0644
 
-    - name: Systemd daemon reloaded
-      when: coturn_cap_net_bind_result is changed
-      systemd:
-        daemon_reload: true
-
 - when: coturn_listening_port >= 1024 and coturn_tls_listening_port >= 1024
   block:
     - name: Listening on privileged port not granted
-      register: coturn_cap_net_bind_result
       notify:
+        - reload systemd
         - restart coturn
       file:
         state: absent
         path: /etc/systemd/system/coturn.service.d/01-cap-net-bind.conf
-
-    - name: Systemd daemon reloaded
-      when: coturn_cap_net_bind_result is changed
-      systemd:
-        daemon_reload: true

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,0 +1,42 @@
+---
+
+- when: coturn_listening_port < 1024 or coturn_tls_listening_port < 1024
+  block:
+    - name: Systemd drop-in directory present
+      file:
+        state: directory
+        path: /etc/systemd/system/coturn.service.d
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Listening on privileged port granted
+      register: coturn_cap_net_bind_result
+      notify:
+        - restart coturn
+      copy:
+        src: systemd-cap-net-bind-override.conf
+        dest: /etc/systemd/system/coturn.service.d/01-cap-net-bind.conf
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Systemd daemon reloaded
+      when: coturn_cap_net_bind_result is changed
+      systemd:
+        daemon_reload: true
+
+- when: coturn_listening_port >= 1024 and coturn_tls_listening_port >= 1024
+  block:
+    - name: Listening on privileged port not granted
+      register: coturn_cap_net_bind_result
+      notify:
+        - restart coturn
+      file:
+        state: absent
+        path: /etc/systemd/system/coturn.service.d/01-cap-net-bind.conf
+
+    - name: Systemd daemon reloaded
+      when: coturn_cap_net_bind_result is changed
+      systemd:
+        daemon_reload: true


### PR DESCRIPTION
This is especially useful for clients behind restrictive firewalls.