### PR TITLE
fix deprecation warning for include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,8 @@
     name: coturn
     state: started
 
-- include: goss.yml
+- name: goss
+  include_tasks:
+    file: goss.yml
   tags:
     - goss


### PR DESCRIPTION
```
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16.
```