### PR TITLE
Add support to configure `no-rfc5780` and `no-stun-backward-compatibility`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,12 @@
 ---
 coturn_listening_port: 3478
+# The alt listening ports require `coturn_no_rfc5780: False`
 #coturn_alt_listening_port:
 coturn_tls_listening_port: 5349
 #coturn_alt_tls_listening_port:
+
+coturn_no_rfc5780: True
+coturn_no_stun_backward_compability: True
 
 # If no IP(s) specified then all IPv4 and IPv6 system IPs will be used for listening.
 coturn_listening_ips: []

--- a/templates/test_coturn.yml.j2
+++ b/templates/test_coturn.yml.j2
@@ -5,12 +5,8 @@ port:
 {% if coturn_tls %}
   tcp:{{ coturn_tls_listening_port }}:
     listening: true
-  tcp:{{ coturn_listening_port|int + 1 }}:
-    listening: true
 {% endif %}
   udp:{{ coturn_listening_port }}:
-    listening: true
-  udp:{{ coturn_listening_port|int + 1 }}:
     listening: true
 service:
   coturn:

--- a/templates/test_coturn.yml.j2
+++ b/templates/test_coturn.yml.j2
@@ -5,9 +5,17 @@ port:
 {% if coturn_tls %}
   tcp:{{ coturn_tls_listening_port }}:
     listening: true
+{% if not coturn_no_rfc5780 %}
+  tcp:{{ coturn_tls_listening_port|int + 1 }}:
+    listening: true
+{% endif %}
 {% endif %}
   udp:{{ coturn_listening_port }}:
     listening: true
+{% if not coturn_no_rfc5780 %}
+  udp:{{ coturn_listening_port|int + 1 }}:
+    listening: true
+{% endif %}
 service:
   coturn:
     enabled: true

--- a/templates/turnserver.conf.j2
+++ b/templates/turnserver.conf.j2
@@ -800,7 +800,7 @@ no-tlsv1_1
 # Strongly encouraged to use this option to decrease gain factor in STUN
 # binding responses.
 #
-no-rfc5780
+{% if not coturn_no_rfc5780 %}#{% endif %}no-rfc5780
 
 # Disable handling old STUN Binding requests and disable MAPPED-ADDRESS
 # attribute in binding response (use only the XOR-MAPPED-ADDRESS).
@@ -808,7 +808,7 @@ no-rfc5780
 # Strongly encouraged to use this option to decrease gain factor in STUN
 # binding responses.
 #
-no-stun-backward-compatibility
+{% if not coturn_no_stun_backward_compability %}#{% endif %}no-stun-backward-compatibility
 
 # Only send RESPONSE-ORIGIN attribute in binding response if RFC5780 is enabled.
 #


### PR DESCRIPTION
Since version 4.6.0, coturn no longer listens on an alternative port if config option `no-rfc5780` is set (which is the default and recommended).

See these upstream commits for details:
https://github.com/coturn/coturn/commit/eda11698f0f5512e0149e807e39b5737187ae33f https://github.com/coturn/coturn/commit/54ef0518440fcc68b67d5baf46a9055ab513bda0